### PR TITLE
Implement the options "rook", "longhorn" in cloud-inint #139

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ NAME             STATUS   ROLES                  AGE     VERSION
 opsv             Ready    control-plane,master   4h58m   v1.29.6+k3s1
 ```
 
+## (Optional) Add block storage rook
+
+```
+multipass exec opsv -- bash -c 'export KUBECONFIG=/home/ubuntu/.kube/config && /home/ubuntu/add-rook'
+
+```
+
+## (Optional) Add block storage longhorn
+
+```
+multipass exec opsv -- bash -c 'export KUBECONFIG=/home/ubuntu/.kube/config && /home/ubuntu/add-longhorn'
+
+```
+
 # Development Environment Overview
 
 If you only want to test OpenServerless, stop here. You should have a working environment.

--- a/cloud-init.yaml
+++ b/cloud-init.yaml
@@ -92,6 +92,69 @@ write_files:
       # TODO add a .git-hooks directory with hooks
       #git config core.hooksPath .git-hooks
  
+  - path: /home/ubuntu/add-rook
+    permissions: '0755'
+    defer: true
+    owner: ubuntu:ubuntu
+    content: |
+      #!/bin/bash
+      set -e
+      echo "📦 Installing Rook..."
+      cd /home/ubuntu
+      git clone --depth 1 https://github.com/rook/rook.git || (cd rook && git pull)
+      cd rook/deploy/examples
+      echo "🔧 Patching Ceph cluster.yaml for single node..."
+      if ! command -v yq >/dev/null 2>&1; then
+        mkdir -p /home/ubuntu/bin
+        wget -qO /home/ubuntu/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+        chmod +x /home/ubuntu/bin/yq
+        export PATH=/home/ubuntu/bin:$PATH
+      fi
+      yq e '.spec.mon.count = 1 | .spec.mon.allowMultiplePerNode = true' -i cluster.yaml
+
+      kubectl apply -f crds.yaml
+      kubectl apply -f common.yaml
+      kubectl apply -f operator.yaml
+      sleep 15
+      kubectl apply -f cluster.yaml
+      sleep 90
+      kubectl apply -f ceph-client.yaml
+      echo "📦 Installing RBD CSI manifests for StorageClass..."
+      kubectl apply -f csi/rbd/
+
+      for i in {1..90}; do
+        status=$(kubectl -n rook-ceph get cephcluster rook-ceph -o jsonpath='{.status.phase}' 2>/dev/null || echo "notfound")
+        echo "⏳ Attempt $i: Rook status = $status"
+        [[ "$status" == "Ready" ]] && echo "✅ Rook Ready" && break
+        sleep 15
+      done
+
+      echo "📦 Setting rook-ceph-block as default storage class (if exists)..."
+      if kubectl get storageclass rook-ceph-block >/dev/null 2>&1; then
+        kubectl annotate storageclass rook-ceph-block storageclass.kubernetes.io/is-default-class=true --overwrite
+      fi
+
+  - path: /home/ubuntu/add-longhorn
+    permissions: '0755'
+    defer: true
+    owner: ubuntu:ubuntu
+    content: |
+      #!/bin/bash
+      echo "📦 Installing Longhorn..."
+      kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.4.1/deploy/longhorn.yaml
+      for i in {1..90}; do
+        ready=$(kubectl -n longhorn-system get pods -l app=longhorn-manager -o jsonpath='{.items[*].status.containerStatuses[0].ready}' | grep -o true | wc -l)
+        total=$(kubectl -n longhorn-system get pods -l app=longhorn-manager --no-headers | wc -l)
+        echo "⏳ Attempt $i: $ready/$total pods ready"
+        [[ "$ready" == "$total" && "$total" -gt 0 ]] && echo "✅ Longhorn Ready" && break
+        sleep 15
+      done
+
+      echo "📦 Setting Longhorn as default storage class (if exists)..."
+      if kubectl get storageclass longhorn >/dev/null 2>&1; then
+        kubectl annotate storageclass longhorn storageclass.kubernetes.io/is-default-class=true --overwrite
+      fi
+
 runcmd:
   - |
     cd /home/ubuntu

--- a/cloud-init.yaml
+++ b/cloud-init.yaml
@@ -99,34 +99,29 @@ write_files:
     content: |
       #!/bin/bash
       set -e
-      echo "📦 Installing Rook v1.14.1..."
-
-      BASE=https://raw.githubusercontent.com/rook/rook/v1.14.1/deploy/examples
-
-      echo "🔧 Applying CRDs and common resources..."
-      kubectl apply -f $BASE/crds.yaml
-      kubectl apply -f $BASE/common.yaml
-
-      echo "🚀 Deploying Rook Operator..."
-      kubectl apply -f $BASE/operator.yaml
-      sleep 15
-
-      echo "🔧 Configuring cluster.yaml for single node..."
-      curl -s $BASE/cluster.yaml -o /tmp/cluster.yaml
-
+      echo "📦 Installing Rook..."
+      cd /home/ubuntu
+      git clone --depth 1 https://github.com/rook/rook.git || (cd rook && git pull)
+      cd rook/deploy/examples
+      echo "🔧 Patching Ceph cluster.yaml for single node..."
       if ! command -v yq >/dev/null 2>&1; then
         mkdir -p /home/ubuntu/bin
         wget -qO /home/ubuntu/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
         chmod +x /home/ubuntu/bin/yq
         export PATH=/home/ubuntu/bin:$PATH
       fi
+      yq e '.spec.mon.count = 1 | .spec.mon.allowMultiplePerNode = true' -i cluster.yaml
 
-      yq e '.spec.mon.count = 1 | .spec.mon.allowMultiplePerNode = true' -i /tmp/cluster.yaml
-      kubectl apply -f /tmp/cluster.yaml
+      kubectl apply -f crds.yaml
+      kubectl apply -f common.yaml
+      kubectl apply -f operator.yaml
+      sleep 15
+      kubectl apply -f cluster.yaml
       sleep 90
+      kubectl apply -f ceph-client.yaml
 
-      echo "📄 Applying Ceph clients..."
-      kubectl apply -f $BASE/ceph-client.yaml
+      echo "📦 Installing RBD CSI manifests (except storageclass.yaml)..."
+      kubectl apply -f csi/rbd/
 
       for i in {1..90}; do
         status=$(kubectl -n rook-ceph get cephcluster rook-ceph -o jsonpath='{.status.phase}' 2>/dev/null || echo "notfound")
@@ -135,11 +130,21 @@ write_files:
         sleep 15
       done
 
-      echo "📦 Trying to set rook-ceph-block as default storage class (non-destructive)..."
+      echo "📦 Waiting for csi-rbdplugin pods to be ready..."
+      for i in {1..90}; do
+        notready=$(kubectl -n rook-ceph get pods -l app=csi-rbdplugin -o jsonpath='{.items[*].status.containerStatuses[*].ready}' | grep -v true | wc -l)
+        total=$(kubectl -n rook-ceph get pods -l app=csi-rbdplugin --no-headers 2>/dev/null | wc -l)
+        echo "⏳ Attempt $i: $((total - notready))/$total pods ready"
+        if [[ "$notready" == "0" && "$total" -gt 0 ]]; then
+          echo "✅ CSI RBD Plugin Ready"
+          break
+        fi
+        sleep 15
+      done
+
       if kubectl get storageclass rook-ceph-block >/dev/null 2>&1; then
-        kubectl annotate storageclass rook-ceph-block storageclass.kubernetes.io/is-default-class=true --overwrite
-      else
-        echo "⚠️  rook-ceph-block not found, skipping annotation"
+        echo "📦 Setting rook-ceph-block as default storage class"
+        kubectl annotate storageclass rook-ceph-block storageclass.kubernetes.io/is-default-class=true --overwrite >/dev/null 2>&1
       fi
 
   - path: /home/ubuntu/add-longhorn

--- a/cloud-init.yaml
+++ b/cloud-init.yaml
@@ -91,7 +91,7 @@ write_files:
       bash direnv-init.sh
       # TODO add a .git-hooks directory with hooks
       #git config core.hooksPath .git-hooks
- 
+
   - path: /home/ubuntu/add-rook
     permissions: '0755'
     defer: true
@@ -99,53 +99,88 @@ write_files:
     content: |
       #!/bin/bash
       set -e
-      echo "📦 Installing Rook..."
-      cd /home/ubuntu
-      git clone --depth 1 https://github.com/rook/rook.git || (cd rook && git pull)
-      cd rook/deploy/examples
-      echo "🔧 Patching Ceph cluster.yaml for single node..."
+
+      ROOK_VERSION="v1.14.6"
+      RAW_BASE="https://raw.githubusercontent.com/rook/rook/${ROOK_VERSION}/deploy/examples"
+
+      echo "📦 Installing Rook ${ROOK_VERSION}"
+      echo "📄 Applying CRDs and operator..."
+      kubectl apply -f ${RAW_BASE}/crds.yaml
+      kubectl apply -f ${RAW_BASE}/common.yaml
+      kubectl apply -f ${RAW_BASE}/operator.yaml
+      sleep 10
+
+      echo "🔎 Checking for yq..."
       if ! command -v yq >/dev/null 2>&1; then
+        echo "📥 Installing yq..."
         mkdir -p /home/ubuntu/bin
-        wget -qO /home/ubuntu/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+        curl -sL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /home/ubuntu/bin/yq
         chmod +x /home/ubuntu/bin/yq
         export PATH=/home/ubuntu/bin:$PATH
+      else
+        echo "✅ yq already installed."
       fi
-      yq e '.spec.mon.count = 1 | .spec.mon.allowMultiplePerNode = true' -i cluster.yaml
 
-      kubectl apply -f crds.yaml
-      kubectl apply -f common.yaml
-      kubectl apply -f operator.yaml
-      sleep 15
-      kubectl apply -f cluster.yaml
-      sleep 90
-      kubectl apply -f ceph-client.yaml
+      echo "🛠️ Patching and applying Ceph cluster for single-node setup..."
+      curl -sL ${RAW_BASE}/cluster.yaml | \
+        yq e '.spec.mon.count = 1 | .spec.mon.allowMultiplePerNode = true' - | \
+        kubectl apply -f -
+      sleep 30
 
-      echo "📦 Installing RBD CSI manifests (except storageclass.yaml)..."
-      kubectl apply -f csi/rbd/
+      echo "📄 Applying Ceph client..."
+      kubectl apply -f ${RAW_BASE}/ceph-client.yaml
 
+      echo "🔍 Waiting for Rook to be Ready..."
       for i in {1..90}; do
         status=$(kubectl -n rook-ceph get cephcluster rook-ceph -o jsonpath='{.status.phase}' 2>/dev/null || echo "notfound")
         echo "⏳ Attempt $i: Rook status = $status"
-        [[ "$status" == "Ready" ]] && echo "✅ Rook Ready" && break
-        sleep 15
-      done
-
-      echo "📦 Waiting for csi-rbdplugin pods to be ready..."
-      for i in {1..90}; do
-        notready=$(kubectl -n rook-ceph get pods -l app=csi-rbdplugin -o jsonpath='{.items[*].status.containerStatuses[*].ready}' | grep -v true | wc -l)
-        total=$(kubectl -n rook-ceph get pods -l app=csi-rbdplugin --no-headers 2>/dev/null | wc -l)
-        echo "⏳ Attempt $i: $((total - notready))/$total pods ready"
-        if [[ "$notready" == "0" && "$total" -gt 0 ]]; then
-          echo "✅ CSI RBD Plugin Ready"
+        if [[ "$status" == "Ready" ]]; then
+          echo "✅ Rook is healthy!"
           break
         fi
         sleep 15
       done
 
-      if kubectl get storageclass rook-ceph-block >/dev/null 2>&1; then
-        echo "📦 Setting rook-ceph-block as default storage class"
-        kubectl annotate storageclass rook-ceph-block storageclass.kubernetes.io/is-default-class=true --overwrite >/dev/null 2>&1
+      if [[ "$status" != "Ready" ]]; then
+        echo "❌ Timeout waiting for Rook to become healthy."
+        exit 1
       fi
+
+      echo "📄 Installing VolumeSnapshot CRDs..."
+      kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v6.3.3/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+      kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v6.3.3/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+      kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v6.3.3/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+
+      echo "🧹 Re-creating rook-ceph-block StorageClass..."
+      kubectl delete storageclass rook-ceph-block --ignore-not-found=true
+
+      cat <<EOF | kubectl apply -f -
+      apiVersion: storage.k8s.io/v1
+      kind: StorageClass
+      metadata:
+        name: rook-ceph-block
+        annotations:
+          storageclass.kubernetes.io/is-default-class: "true"
+      provisioner: rook-ceph.rbd.csi.ceph.com
+      allowVolumeExpansion: true
+      reclaimPolicy: Delete
+      volumeBindingMode: WaitForFirstConsumer
+      parameters:
+        clusterID: rook-ceph
+        pool: replicapool
+        imageFormat: "2"
+        imageFeatures: layering
+        csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+        csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+        csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+        csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+        csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+        csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+        csi.storage.k8s.io/fstype: ext4
+      EOF
+
+      echo "✅ Rook installed and configured with default StorageClass rook-ceph-block."
+
 
   - path: /home/ubuntu/add-longhorn
     permissions: '0755'
@@ -154,8 +189,10 @@ write_files:
     content: |
       #!/bin/bash
       set -e
-      echo "📦 Installing Longhorn v1.4.1..."
-      kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.4.1/deploy/longhorn.yaml
+      LONGHORN_VERSION="v1.4.1"
+      
+      echo "📦 Installing Longhorn ${LONGHORN_VERSION}"
+      kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_VERSION}/deploy/longhorn.yaml
 
       for i in {1..90}; do
         ready=$(kubectl -n longhorn-system get pods -l app=longhorn-manager -o jsonpath='{.items[*].status.containerStatuses[0].ready}' | grep -o true | wc -l)
@@ -165,7 +202,7 @@ write_files:
         sleep 15
       done
 
-      echo "📦 Trying to set Longhorn as default storage class (non-destructive)..."
+      echo "📦 Trying to set Longhorn as default storage class ..."
       if kubectl get storageclass longhorn >/dev/null 2>&1; then
         kubectl annotate storageclass longhorn storageclass.kubernetes.io/is-default-class=true --overwrite || true
       fi

--- a/cloud-init.yaml
+++ b/cloud-init.yaml
@@ -110,7 +110,6 @@ write_files:
       kubectl apply -f ${RAW_BASE}/operator.yaml
       sleep 10
 
-      echo "🔎 Checking for yq..."
       if ! command -v yq >/dev/null 2>&1; then
         echo "📥 Installing yq..."
         mkdir -p /home/ubuntu/bin
@@ -181,7 +180,6 @@ write_files:
 
       echo "✅ Rook installed and configured with default StorageClass rook-ceph-block."
 
-
   - path: /home/ubuntu/add-longhorn
     permissions: '0755'
     defer: true
@@ -189,6 +187,7 @@ write_files:
     content: |
       #!/bin/bash
       set -e
+
       LONGHORN_VERSION="v1.4.1"
       
       echo "📦 Installing Longhorn ${LONGHORN_VERSION}"

--- a/cloud-init.yaml
+++ b/cloud-init.yaml
@@ -99,28 +99,34 @@ write_files:
     content: |
       #!/bin/bash
       set -e
-      echo "📦 Installing Rook..."
-      cd /home/ubuntu
-      git clone --depth 1 https://github.com/rook/rook.git || (cd rook && git pull)
-      cd rook/deploy/examples
-      echo "🔧 Patching Ceph cluster.yaml for single node..."
+      echo "📦 Installing Rook v1.14.1..."
+
+      BASE=https://raw.githubusercontent.com/rook/rook/v1.14.1/deploy/examples
+
+      echo "🔧 Applying CRDs and common resources..."
+      kubectl apply -f $BASE/crds.yaml
+      kubectl apply -f $BASE/common.yaml
+
+      echo "🚀 Deploying Rook Operator..."
+      kubectl apply -f $BASE/operator.yaml
+      sleep 15
+
+      echo "🔧 Configuring cluster.yaml for single node..."
+      curl -s $BASE/cluster.yaml -o /tmp/cluster.yaml
+
       if ! command -v yq >/dev/null 2>&1; then
         mkdir -p /home/ubuntu/bin
         wget -qO /home/ubuntu/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
         chmod +x /home/ubuntu/bin/yq
         export PATH=/home/ubuntu/bin:$PATH
       fi
-      yq e '.spec.mon.count = 1 | .spec.mon.allowMultiplePerNode = true' -i cluster.yaml
 
-      kubectl apply -f crds.yaml
-      kubectl apply -f common.yaml
-      kubectl apply -f operator.yaml
-      sleep 15
-      kubectl apply -f cluster.yaml
+      yq e '.spec.mon.count = 1 | .spec.mon.allowMultiplePerNode = true' -i /tmp/cluster.yaml
+      kubectl apply -f /tmp/cluster.yaml
       sleep 90
-      kubectl apply -f ceph-client.yaml
-      echo "📦 Installing RBD CSI manifests for StorageClass..."
-      kubectl apply -f csi/rbd/
+
+      echo "📄 Applying Ceph clients..."
+      kubectl apply -f $BASE/ceph-client.yaml
 
       for i in {1..90}; do
         status=$(kubectl -n rook-ceph get cephcluster rook-ceph -o jsonpath='{.status.phase}' 2>/dev/null || echo "notfound")
@@ -129,9 +135,11 @@ write_files:
         sleep 15
       done
 
-      echo "📦 Setting rook-ceph-block as default storage class (if exists)..."
+      echo "📦 Trying to set rook-ceph-block as default storage class (non-destructive)..."
       if kubectl get storageclass rook-ceph-block >/dev/null 2>&1; then
         kubectl annotate storageclass rook-ceph-block storageclass.kubernetes.io/is-default-class=true --overwrite
+      else
+        echo "⚠️  rook-ceph-block not found, skipping annotation"
       fi
 
   - path: /home/ubuntu/add-longhorn
@@ -140,8 +148,10 @@ write_files:
     owner: ubuntu:ubuntu
     content: |
       #!/bin/bash
-      echo "📦 Installing Longhorn..."
+      set -e
+      echo "📦 Installing Longhorn v1.4.1..."
       kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.4.1/deploy/longhorn.yaml
+
       for i in {1..90}; do
         ready=$(kubectl -n longhorn-system get pods -l app=longhorn-manager -o jsonpath='{.items[*].status.containerStatuses[0].ready}' | grep -o true | wc -l)
         total=$(kubectl -n longhorn-system get pods -l app=longhorn-manager --no-headers | wc -l)
@@ -150,9 +160,9 @@ write_files:
         sleep 15
       done
 
-      echo "📦 Setting Longhorn as default storage class (if exists)..."
+      echo "📦 Trying to set Longhorn as default storage class (non-destructive)..."
       if kubectl get storageclass longhorn >/dev/null 2>&1; then
-        kubectl annotate storageclass longhorn storageclass.kubernetes.io/is-default-class=true --overwrite
+        kubectl annotate storageclass longhorn storageclass.kubernetes.io/is-default-class=true --overwrite || true
       fi
 
 runcmd:


### PR DESCRIPTION
Why you need it?
We need to be able to install in the development vm also longhhorn and rook

How it could be?
The internal script ./waitready should accept an optionan argument "longhorn" or "rook" and install in the k3s also longhorhn or rook and enable it as default storage class

Other related information
Embed the script in cloud-init

For Testing:
Create VM => multipass launch -nopsv -c6 -d40g -m16g --cloud-init cloud-init.yaml

For add rook=> multipass exec opsv -- bash -c 'export KUBECONFIG=/home/ubuntu/.kube/config && /home/ubuntu/add-rook'

For add Longhorn =>  multipass exec opsv -- bash -c 'export KUBECONFIG=/home/ubuntu/.kube/config && /home/ubuntu/add-longhorn'

